### PR TITLE
Add kexec option

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -21,6 +21,9 @@
         <entry name="showReboot" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="showKexec" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="showShutdown" type="Bool">
             <default>true</default>
         </entry>

--- a/contents/ui/configAppearance.qml
+++ b/contents/ui/configAppearance.qml
@@ -10,6 +10,7 @@ Item {
     property alias cfg_showSuspend: showSuspend.checked
     property alias cfg_showHibernate: showHibernate.checked
     property alias cfg_showReboot: showReboot.checked
+    property alias cfg_showKexec: showKexec.checked
     property alias cfg_showShutdown: showShutdown.checked
     property alias cfg_width: widthSpinBox.value
     property alias cfg_height: heightSpinBox.value
@@ -42,6 +43,11 @@ Item {
         CheckBox {
             id: showReboot
             text: i18n('Reboot')
+            Layout.columnSpan: 2
+        }
+        CheckBox {
+            id: showKexec
+            text: i18n('Kexec Reboot')
             Layout.columnSpan: 2
         }
         CheckBox {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -19,6 +19,7 @@ Item {
     property bool showSuspend: plasmoid.configuration.showSuspend
     property bool showHibernate: plasmoid.configuration.showHibernate
     property bool showReboot: plasmoid.configuration.showReboot
+    property bool showKexec: plasmoid.configuration.showKexec
     property bool showShutdown: plasmoid.configuration.showShutdown
 
     Layout.fillWidth: true
@@ -59,6 +60,10 @@ Item {
 
     function action_reBoot() {
         executable.exec('qdbus org.kde.ksmserver /KSMServer logout 0 1 2')
+    }
+
+    function action_kexec() {
+        executable.exec('qdbus --system org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.StartUnit kexec.target replace-irreversibly')
     }
     
     function action_lockScreen() {
@@ -138,6 +143,16 @@ Item {
                 onClicked: action_reBoot()
                 visible: showReboot
             }
+
+            ListDelegate {
+                id: kexecButton
+                text: i18n("kexec Reboot")
+                highlight: delegateHighlight
+                icon: "system-reboot"
+                onClicked: action_kexec()
+                visible: showKexec
+            }
+
             ListDelegate {
                 id: shutdownButton
                 text: i18n("Shutdown")


### PR DESCRIPTION
Hello,
this adds the ability to reboot via kexec. That saves like nine seconds on the boot of my computer. Kexec needs to work, which is out of scope of this application (in general, systemd-boot must be used or something compatbile that will tell systemd about installed kernels and kexec-tools must be installeed).

There are two issues:
1) I reuse the reboot icon. Maybe no icon could be used. I do not think there really is an icon for kexec.
2) The way to initiate kexec via qdbus. Now I am opting for 

`qdbus --system org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.StartUnit kexec.target replace-irreversibly`

This has the advantage it works on my system but the disadvantage it prompts for password (I configured my system to allow this to run without needing my password).

There is another option

`qdbus --system org.freedesktop.login1 /org/freedesktop/login1 org.freedesktop.login1.Manager.RebootWithFlags 2`

which does not need priviledges but on my system does not work without manually loading kexec kernel. Now thinking about it, the second option might probably be preferable.

It is disabled by default.
